### PR TITLE
TOOLS-2812 add hosts and policy helpers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,70 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '21 12 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ test:
 .PHONY: coverage
 coverage:
 	go test ./... -coverprofile coverage.cov -coverpkg ./... || true
-	grep -v "_mock.go" coverage.cov > coverage_no_mocks.cov && mv coverage_no_mocks.cov coverage.cov
-	grep -v "test/" coverage.cov > coverage_no_mocks.cov && mv coverage_no_mocks.cov coverage.cov
 	go tool cover -func coverage.cov
 
 .PHONY: clean

--- a/client/config.go
+++ b/client/config.go
@@ -1,0 +1,123 @@
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	as "github.com/aerospike/aerospike-client-go/v6"
+)
+
+type AerospikeConfig struct {
+	Seeds                  HostTLSPortSlice
+	User                   string
+	Password               string
+	AuthMode               as.AuthMode
+	RootCA                 [][]byte
+	Cert                   []byte
+	Key                    []byte
+	KeyPass                []byte
+	TLSProtocolsMinVersion TLSProtocol
+	TLSProtocolsMaxVersion TLSProtocol
+	// TLSCipherSuites        []uint16 // TODO
+}
+
+func NewDefaultAerospikeHostConfig() *AerospikeConfig {
+	return &AerospikeConfig{
+		Seeds: HostTLSPortSlice{NewDefaultHostTLSPort()},
+	}
+}
+
+func (config *AerospikeConfig) NewTLSConfig() (*tls.Config, error) {
+	if len(config.RootCA) == 0 && len(config.Cert) == 0 && len(config.Key) == 0 {
+		return nil, nil
+	}
+
+	var clientPool []tls.Certificate
+	var serverPool *x509.CertPool
+	var err error
+
+	serverPool, err = loadCACerts(config.RootCA)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA certificates: `%s`", err)
+	}
+
+	if len(config.Cert) > 0 || len(config.Key) > 0 {
+		clientPool, err = loadServerCertAndKey(config.Cert, config.Key, config.KeyPass)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load server certificate and key: `%s`", err)
+		}
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates:             clientPool,
+		RootCAs:                  serverPool,
+		InsecureSkipVerify:       false,
+		PreferServerCipherSuites: true,
+		MinVersion:               uint16(config.TLSProtocolsMinVersion),
+		MaxVersion:               uint16(config.TLSProtocolsMaxVersion),
+	}
+
+	return tlsConfig, nil
+}
+
+// loadCACerts returns CA set of certificates (cert pool)
+// reads CA certificate based on the certConfig and adds it to the pool
+func loadCACerts(certsBytes [][]byte) (*x509.CertPool, error) {
+	certificates, err := x509.SystemCertPool()
+	if certificates == nil || err != nil {
+		certificates = x509.NewCertPool()
+	}
+
+	for _, cert := range certsBytes {
+		if len(cert) > 0 {
+			certificates.AppendCertsFromPEM(cert)
+		}
+	}
+
+	return certificates, nil
+}
+
+// loadServerCertAndKey reads server certificate and associated key file based on certConfig and keyConfig
+// returns parsed server certificate
+// if the private key is encrypted, it will be decrypted using key file passphrase
+func loadServerCertAndKey(certFileBytes, keyFileBytes, keyPassBytes []byte) ([]tls.Certificate, error) {
+	var certificates []tls.Certificate
+
+	// Decode PEM data
+	keyBlock, _ := pem.Decode(keyFileBytes)
+
+	if keyBlock == nil {
+		return nil, fmt.Errorf("failed to decode PEM data for key or certificate")
+	}
+
+	// Check and Decrypt the Key Block using passphrase
+	if x509.IsEncryptedPEMBlock(keyBlock) {
+
+		decryptedDERBytes, err := x509.DecryptPEMBlock(keyBlock, keyPassBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt PEM Block: `%s`", err)
+		}
+
+		keyBlock.Bytes = decryptedDERBytes
+		keyBlock.Headers = nil
+	}
+
+	// Encode PEM data
+	keyPEM := pem.EncodeToMemory(keyBlock)
+
+	if keyPEM == nil {
+		return nil, fmt.Errorf("failed to encode PEM data for key or certificate")
+	}
+
+	cert, err := tls.X509KeyPair(certFileBytes, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add certificate and key to the pool: `%s`", err)
+	}
+
+	certificates = append(certificates, cert)
+
+	return certificates, nil
+}

--- a/client/config.go
+++ b/client/config.go
@@ -36,7 +36,6 @@ func (ac *AerospikeConfig) NewClientPolicy() (*as.ClientPolicy, error) {
 	clientPolicy.AuthMode = ac.AuthMode
 
 	tlsConfig, err := ac.newTLSConfig()
-
 	if err != nil {
 		return nil, err
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -77,7 +77,7 @@ func (ac *AerospikeConfig) newTLSConfig() (*tls.Config, error) {
 	if len(ac.Cert) > 0 || len(ac.Key) > 0 {
 		clientPool, err = loadServerCertAndKey(ac.Cert, ac.Key, ac.KeyPass)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load server certificate and key: `%s`", err)
+			return nil, fmt.Errorf("failed to load client authentication certificate and key `%s`", err)
 		}
 	}
 

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -53,9 +53,7 @@ func TestAerospikeConfig_NewClientPolicy(t *testing.T) {
 	expectedClientPolicy := as.NewClientPolicy()
 	expectedClientPolicy.User = config.User
 	expectedClientPolicy.Password = config.Password
-	expectedClientPolicy.Timeout = defaultTimeout
 	expectedClientPolicy.AuthMode = config.AuthMode
-	expectedClientPolicy.TendInterval = defaultTendInterval
 	expectedClientPolicy.TlsConfig = nil
 
 	clientPolicy, err := config.NewClientPolicy()
@@ -253,27 +251,22 @@ func TestLoadCACerts(t *testing.T) {
 		name           string
 		certsBytes     [][]byte
 		expectedOutput *x509.CertPool
-		expectedError  error
 	}{
 		{
 			name:           "ValidCerts",
 			certsBytes:     [][]byte{cert1, cert2},
 			expectedOutput: expectedPool,
-			expectedError:  nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput, actualError := loadCACerts(tc.certsBytes)
+			actualOutput := loadCACerts(tc.certsBytes)
 
 			if !reflect.DeepEqual(actualOutput, tc.expectedOutput) {
 				t.Errorf("loadCACerts() output = %v, want %v", actualOutput, tc.expectedOutput)
 			}
 
-			if !errorsEqual(actualError, tc.expectedError) {
-				t.Errorf("loadCACerts() error = %v, want %v", actualError, tc.expectedError)
-			}
 		})
 	}
 }

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -1,0 +1,218 @@
+package client
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var key, _ = rsa.GenerateKey(rand.Reader, 512)
+
+// Encode private key to PKCS#1 ASN.1 PEM.
+var keyFileBytes = pem.EncodeToMemory(
+	&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	},
+)
+
+// Generate certificate
+var tml = x509.Certificate{
+	NotBefore:    time.Now(),
+	NotAfter:     time.Now().AddDate(5, 0, 0),
+	SerialNumber: big.NewInt(123123),
+	Subject: pkix.Name{
+		CommonName:   "New Name",
+		Organization: []string{"New Org."},
+	},
+	BasicConstraintsValid: true,
+}
+var cert, _ = x509.CreateCertificate(rand.Reader, &tml, &tml, &key.PublicKey, key)
+var certFileBytes = pem.EncodeToMemory(&pem.Block{
+	Type:  "CERTIFICATE",
+	Bytes: cert,
+})
+
+func TestAerospikeConfig_NewTLSConfig(t *testing.T) {
+	emptyConfig := &AerospikeConfig{}
+	nilTLSConfig, _ := emptyConfig.NewTLSConfig()
+	if nilTLSConfig != nil {
+		t.Errorf("NewTLSConfig() should return nil when config is empty")
+	}
+
+	config := &AerospikeConfig{
+		RootCA:                 [][]byte{[]byte("fakecert1")},
+		Cert:                   certFileBytes,
+		Key:                    keyFileBytes,
+		KeyPass:                []byte("fakepassphrase"),
+		TLSProtocolsMinVersion: 1,
+		TLSProtocolsMaxVersion: 3,
+	}
+	expectedServerPool, _ := x509.SystemCertPool()
+	expectedServerPool.AppendCertsFromPEM(config.RootCA[0])
+	expectedClientPool, _ := loadServerCertAndKey(config.Cert, config.Key, config.KeyPass)
+
+	tlsConfig, err := config.NewTLSConfig()
+	if err != nil {
+		t.Errorf("NewTLSConfig() returned an unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(tlsConfig.RootCAs, expectedServerPool) {
+		t.Errorf("NewTLSConfig() returned incorrect RootCAs, got %v, want %v", tlsConfig.RootCAs, expectedServerPool)
+	}
+
+	if !reflect.DeepEqual(tlsConfig.Certificates, expectedClientPool) {
+		t.Errorf("NewTLSConfig() returned incorrect Certificates, got %v, want %v", tlsConfig.Certificates, expectedClientPool)
+	}
+
+	if tlsConfig.InsecureSkipVerify {
+		t.Errorf("NewTLSConfig() should have InsecureSkipVerify set to false")
+	}
+
+	if !tlsConfig.PreferServerCipherSuites {
+		t.Errorf("NewTLSConfig() should have PreferServerCipherSuites set to true")
+	}
+
+	if tlsConfig.MinVersion != uint16(config.TLSProtocolsMinVersion) {
+		t.Errorf("NewTLSConfig() returned incorrect MinVersion, got %v, want %v", tlsConfig.MinVersion, config.TLSProtocolsMinVersion)
+	}
+
+	if tlsConfig.MaxVersion != uint16(config.TLSProtocolsMaxVersion) {
+		t.Errorf("NewTLSConfig() returned incorrect MaxVersion, got %v, want %v", tlsConfig.MaxVersion, config.TLSProtocolsMaxVersion)
+	}
+}
+
+func TestNewDefaultAerospikeHostConfig(t *testing.T) {
+	expectedConfig := &AerospikeConfig{
+		Seeds: HostTLSPortSlice{NewDefaultHostTLSPort()},
+	}
+
+	actualConfig := NewDefaultAerospikeHostConfig()
+
+	if !reflect.DeepEqual(actualConfig, expectedConfig) {
+		t.Errorf("NewDefaultAerospikeHostConfig() = %v, want %v", actualConfig, expectedConfig)
+	}
+}
+
+func TestLoadServerCertAndKey(t *testing.T) {
+	keyPassBytes := []byte("fakepassphrase")
+	expectedCert, _ := tls.X509KeyPair(certFileBytes, keyFileBytes)
+
+	testCases := []struct {
+		name           string
+		certFileBytes  []byte
+		keyFileBytes   []byte
+		keyPassBytes   []byte
+		expectedOutput []tls.Certificate
+		expectedError  error
+	}{
+		{
+			name:           "ValidCertAndKey",
+			certFileBytes:  certFileBytes,
+			keyFileBytes:   keyFileBytes,
+			keyPassBytes:   keyPassBytes,
+			expectedOutput: []tls.Certificate{expectedCert},
+			expectedError:  nil,
+		},
+		{
+			name:           "InvalidKeyBlock",
+			certFileBytes:  certFileBytes,
+			keyFileBytes:   []byte("invalidkeyblock"),
+			keyPassBytes:   keyPassBytes,
+			expectedOutput: nil,
+			expectedError:  fmt.Errorf("failed to decode PEM data for key or certificate"),
+		},
+		{
+			name:           "EncryptedKeyBlock",
+			certFileBytes:  certFileBytes,
+			keyFileBytes:   encryptPEMBlock(keyFileBytes, keyPassBytes),
+			keyPassBytes:   keyPassBytes,
+			expectedOutput: []tls.Certificate{expectedCert},
+			expectedError:  nil,
+		},
+		{
+			name:           "InvalidPassphrase",
+			certFileBytes:  certFileBytes,
+			keyFileBytes:   encryptPEMBlock(keyFileBytes, []byte("wrongpassphrase")),
+			keyPassBytes:   keyPassBytes,
+			expectedOutput: nil,
+			expectedError:  fmt.Errorf("failed to decrypt PEM Block: `x509: decryption password incorrect`"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput, actualError := loadServerCertAndKey(tc.certFileBytes, tc.keyFileBytes, tc.keyPassBytes)
+
+			if !reflect.DeepEqual(actualOutput, tc.expectedOutput) {
+				t.Errorf("loadServerCertAndKey() output = %v, want %v", actualOutput, tc.expectedOutput)
+			}
+
+			if !errorsEqual(actualError, tc.expectedError) {
+				t.Errorf("loadServerCertAndKey() error = %v, want %v", actualError, tc.expectedError)
+			}
+		})
+	}
+}
+
+func encryptPEMBlock(keyFileBytes, keyPassBytes []byte) []byte {
+	block, _ := pem.Decode(keyFileBytes)
+
+	encryptedBlock, _ := x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, keyPassBytes, x509.PEMCipherAES256)
+
+	return pem.EncodeToMemory(encryptedBlock)
+}
+
+func errorsEqual(err1, err2 error) bool {
+	if err1 == nil && err2 == nil {
+		return true
+	}
+	if err1 == nil || err2 == nil {
+		return false
+	}
+	return err1.Error() == err2.Error()
+}
+
+func TestLoadCACerts(t *testing.T) {
+	cert1 := []byte("fakecert1")
+	cert2 := []byte("fakecert2")
+	expectedPool, _ := x509.SystemCertPool()
+	expectedPool.AppendCertsFromPEM(cert1)
+	expectedPool.AppendCertsFromPEM(cert2)
+
+	testCases := []struct {
+		name           string
+		certsBytes     [][]byte
+		expectedOutput *x509.CertPool
+		expectedError  error
+	}{
+		{
+			name:           "ValidCerts",
+			certsBytes:     [][]byte{cert1, cert2},
+			expectedOutput: expectedPool,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput, actualError := loadCACerts(tc.certsBytes)
+
+			if !reflect.DeepEqual(actualOutput, tc.expectedOutput) {
+				t.Errorf("loadCACerts() output = %v, want %v", actualOutput, tc.expectedOutput)
+			}
+
+			if !errorsEqual(actualError, tc.expectedError) {
+				t.Errorf("loadCACerts() error = %v, want %v", actualError, tc.expectedError)
+			}
+		})
+	}
+}

--- a/client/host.go
+++ b/client/host.go
@@ -11,8 +11,8 @@ type HostTLSPort struct {
 	Port    int
 }
 
-const DEFAULT_PORT = 3000
-const DEFAULT_IPV4 = "127.0.0.1"
+const DefaultPort = 3000
+const DefaultIPv4 = "127.0.0.1"
 
 func NewHostTLSPort() *HostTLSPort {
 	return &HostTLSPort{}
@@ -20,9 +20,9 @@ func NewHostTLSPort() *HostTLSPort {
 
 func NewDefaultHostTLSPort() *HostTLSPort {
 	return &HostTLSPort{
-		DEFAULT_IPV4,
+		DefaultIPv4,
 		"",
-		DEFAULT_PORT,
+		DefaultPort,
 	}
 }
 

--- a/client/host.go
+++ b/client/host.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+type HostTLSPort struct {
+	Host    string // Can be ipv4, ipv6, or hostname.
+	TLSName string
+	Port    int
+}
+
+const DEFAULT_PORT = 3000
+const DEFAULT_IPV4 = "127.0.0.1"
+
+func NewHostTLSPort() *HostTLSPort {
+	return &HostTLSPort{}
+}
+
+func NewDefaultHostTLSPort() *HostTLSPort {
+	return &HostTLSPort{
+		DEFAULT_IPV4,
+		"",
+		DEFAULT_PORT,
+	}
+}
+
+func (addr *HostTLSPort) String() string {
+	str := addr.Host
+
+	if addr.TLSName != "" {
+		str = fmt.Sprintf("%s:%s", str, addr.TLSName)
+	}
+
+	if addr.Port != 0 {
+		str = fmt.Sprintf("%s:%v", str, addr.Port)
+	}
+
+	return str
+}
+
+type HostTLSPortSlice []*HostTLSPort
+
+func (slice *HostTLSPortSlice) String() string {
+	strs := []string{}
+
+	for _, elem := range *slice {
+		strs = append(strs, elem.String())
+	}
+
+	if len(strs) == 1 {
+		return strs[0]
+	}
+
+	str := fmt.Sprintf("[%s]", strings.Join(strs, ", "))
+
+	return str
+}

--- a/client/host_test.go
+++ b/client/host_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestNewDefaultHostTLSPort(t *testing.T) {
+	expected := NewHostTLSPort()
+	expected.Host = DEFAULT_IPV4
+	expected.Port = DEFAULT_PORT
+	expected.TLSName = ""
+
+	result := NewDefaultHostTLSPort()
+
+	if result.Host != expected.Host {
+		t.Errorf("Expected Host %s, but got %s", expected.Host, result.Host)
+	}
+
+	if result.TLSName != expected.TLSName {
+		t.Errorf("Expected TLSName %s, but got %s", expected.TLSName, result.TLSName)
+	}
+
+	if result.Port != expected.Port {
+		t.Errorf("Expected Port %d, but got %d", expected.Port, result.Port)
+	}
+}
+
+func TestHostTLSPortString(t *testing.T) {
+	host := "example.com"
+	tlsName := "example"
+	port := 8080
+
+	addr := &HostTLSPort{
+		Host:    host,
+		TLSName: tlsName,
+		Port:    port,
+	}
+
+	expected := "example.com:example:8080"
+	result := addr.String()
+
+	if result != expected {
+		t.Errorf("Expected %s, but got %s", expected, result)
+	}
+}
+
+func TestHostTLSPortSliceString(t *testing.T) {
+	addr1 := &HostTLSPort{
+		Host:    "example1.com",
+		TLSName: "example1",
+		Port:    8080,
+	}
+
+	addr2 := &HostTLSPort{
+		Host:    "example2.com",
+		TLSName: "example2",
+		Port:    9090,
+	}
+
+	slice := HostTLSPortSlice{addr1, addr2}
+
+	expected := "[example1.com:example1:8080, example2.com:example2:9090]"
+	result := slice.String()
+
+	if result != expected {
+		t.Errorf("Expected %s, but got %s", expected, result)
+	}
+}

--- a/client/host_test.go
+++ b/client/host_test.go
@@ -6,8 +6,8 @@ import (
 
 func TestNewDefaultHostTLSPort(t *testing.T) {
 	expected := NewHostTLSPort()
-	expected.Host = DEFAULT_IPV4
-	expected.Port = DEFAULT_PORT
+	expected.Host = DefaultIPv4
+	expected.Port = DefaultPort
 	expected.TLSName = ""
 
 	result := NewDefaultHostTLSPort()

--- a/client/tls.go
+++ b/client/tls.go
@@ -6,7 +6,7 @@ type TLSProtocol uint16
 
 const (
 	VersionTLSDefaultMin = tls.VersionTLS12
-	VersionTLSDefaultMax = tls.VersionTLS12
+	VersionTLSDefaultMax = tls.VersionTLS13
 )
 
 func (p TLSProtocol) String() string {

--- a/client/tls.go
+++ b/client/tls.go
@@ -17,6 +17,8 @@ func (p TLSProtocol) String() string {
 		return "TLSV1.1"
 	case tls.VersionTLS12:
 		return "TLSV1.2"
+	case tls.VersionTLS13:
+		return "TLSV1.3"
 	}
 
 	return ""

--- a/client/tls.go
+++ b/client/tls.go
@@ -1,0 +1,23 @@
+package client
+
+import "crypto/tls"
+
+type TLSProtocol uint16
+
+const (
+	VersionTLSDefaultMin = tls.VersionTLS12
+	VersionTLSDefaultMax = tls.VersionTLS12
+)
+
+func (p TLSProtocol) String() string {
+	switch p {
+	case tls.VersionTLS10:
+		return "TLSV1"
+	case tls.VersionTLS11:
+		return "TLSV1.1"
+	case tls.VersionTLS12:
+		return "TLSV1.2"
+	}
+
+	return ""
+}

--- a/client/tls_test.go
+++ b/client/tls_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestTLSProtocol_String(t *testing.T) {
+	tests := []struct {
+		protocol TLSProtocol
+		expected string
+	}{
+		{TLSProtocol(tls.VersionTLS10), "TLSV1"},
+		{TLSProtocol(tls.VersionTLS11), "TLSV1.1"},
+		{TLSProtocol(tls.VersionTLS12), "TLSV1.2"},
+	}
+
+	for _, test := range tests {
+		result := test.protocol.String()
+		if result != test.expected {
+			t.Errorf("Expected TLSProtocol.String() to return '%s', but got '%s'", test.expected, result)
+		}
+	}
+}

--- a/client/tls_test.go
+++ b/client/tls_test.go
@@ -13,6 +13,7 @@ func TestTLSProtocol_String(t *testing.T) {
 		{TLSProtocol(tls.VersionTLS10), "TLSV1"},
 		{TLSProtocol(tls.VersionTLS11), "TLSV1.1"},
 		{TLSProtocol(tls.VersionTLS12), "TLSV1.2"},
+		{TLSProtocol(tls.VersionTLS13), "TLSV1.3"},
 	}
 
 	for _, test := range tests {

--- a/flags/authmode_test.go
+++ b/flags/authmode_test.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"testing"
 
+	"github.com/aerospike/tools-common-go/client"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -19,7 +20,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.1",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "127.0.0.1",
 					},
@@ -30,7 +31,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.1,127.0.0.2",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "127.0.0.1",
 					},
@@ -44,7 +45,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.2:3002",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "127.0.0.2",
 						Port: 3002,
@@ -56,7 +57,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.2:3002,127.0.0.3:3003",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "127.0.0.2",
 						Port: 3002,
@@ -72,7 +73,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.3:tls-name:3003",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "127.0.0.3",
 						TLSName: "tls-name",
@@ -85,7 +86,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.3:tls-name:3003,127.0.0.4:tls-name4:3004",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "127.0.0.3",
 						TLSName: "tls-name",
@@ -103,7 +104,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"127.0.0.3:3003,127.0.0.4:tls-name4:3004",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "127.0.0.3",
 						Port: 3003,
@@ -120,7 +121,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 					},
@@ -131,7 +132,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"[fe80::1ff:fe23:4567:890a]:3002",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "fe80::1ff:fe23:4567:890a",
 						Port: 3002,
@@ -143,7 +144,7 @@ func (suite *HostTestSuite) TestHostTLSPort() {
 			"[100::]:tls-name:3003",
 			HostTLSPortSliceFlag{
 				useDefault: false,
-				Seeds: HostTLSPortSlice{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "100::",
 						TLSName: "tls-name",

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -16,7 +16,7 @@ const (
 // get the values from an AerospikeFlags structure into an easier to use state.
 // AerospikeConfig is usually used to configure the Aerospike Go client.
 type AerospikeConfig struct {
-	Seeds                  HostTLSPortSlice
+	Seeds                  client.HostTLSPortSlice
 	User                   string
 	Password               string
 	AuthMode               as.AuthMode
@@ -24,14 +24,14 @@ type AerospikeConfig struct {
 	Cert                   []byte
 	Key                    []byte
 	KeyPass                []byte
-	TLSProtocolsMinVersion TLSProtocol
-	TLSProtocolsMaxVersion TLSProtocol
+	TLSProtocolsMinVersion client.TLSProtocol
+	TLSProtocolsMaxVersion client.TLSProtocol
 	// TLSCipherSuites        []uint16 // TODO
 }
 
 func NewDefaultAerospikeConfig() *AerospikeConfig {
 	return &AerospikeConfig{
-		Seeds: HostTLSPortSlice{NewDefaultHostTLSPort()},
+		Seeds: client.HostTLSPortSlice{client.NewDefaultHostTLSPort()},
 	}
 }
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -12,29 +12,6 @@ const (
 	DefaultMaxLineLength = 65
 )
 
-// AerospikeConfig can be used with SetAerospikeConf to
-// get the values from an AerospikeFlags structure into an easier to use state.
-// AerospikeConfig is usually used to configure the Aerospike Go client.
-type AerospikeConfig struct {
-	Seeds                  client.HostTLSPortSlice
-	User                   string
-	Password               string
-	AuthMode               as.AuthMode
-	RootCA                 [][]byte
-	Cert                   []byte
-	Key                    []byte
-	KeyPass                []byte
-	TLSProtocolsMinVersion client.TLSProtocol
-	TLSProtocolsMaxVersion client.TLSProtocol
-	// TLSCipherSuites        []uint16 // TODO
-}
-
-func NewDefaultAerospikeConfig() *AerospikeConfig {
-	return &AerospikeConfig{
-		Seeds: client.HostTLSPortSlice{client.NewDefaultHostTLSPort()},
-	}
-}
-
 // AerospikeFlags defines the storage backing
 // for Aerospike pflags.FlagSet returned from SetAerospikeFlags.
 type AerospikeFlags struct {

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	as "github.com/aerospike/aerospike-client-go/v6"
+	"github.com/aerospike/tools-common-go/client"
 	"github.com/spf13/pflag"
 )
 
@@ -63,7 +64,7 @@ func NewDefaultAerospikeFlags() *AerospikeFlags {
 
 // SetAerospikeConf sets the values in aerospikeConf based on the values set in flags.
 // This function is useful for using AerospikeFlags to configure the Aerospike Go client.
-func SetAerospikeConf(aerospikeConf *AerospikeConfig, flags *AerospikeFlags) {
+func SetAerospikeConf(aerospikeConf *client.AerospikeConfig, flags *AerospikeFlags) {
 	aerospikeConf.Seeds = flags.Seeds.Seeds
 	aerospikeConf.User = flags.User
 	aerospikeConf.Password = string(flags.Password)

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -201,8 +201,75 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 	}
 }
 
+func (suite *FlagsTestSuite) TestWrapString() {
+	testCases := []struct {
+		input    string
+		lineLen  int
+		expected string
+	}{
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			lineLen:  20,
+			expected: "Lorem ipsum dolor\nsit amet,\nconsectetur\nadipiscing elit.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			lineLen:  30,
+			expected: "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			lineLen:  50,
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing\nelit.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			lineLen:  80,
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			lineLen:  100,
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run("", func(t *testing.T) {
+			actual := WrapString(tc.input, tc.lineLen)
+			suite.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRunFlagsTestSuite(t *testing.T) {
 	suite.Run(t, new(FlagsTestSuite))
+}
+func TestDefaultWrapHelpString(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.",
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut perspiciatis unde\nomnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem\naperiam.",
+		},
+		{
+			input:    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam. Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
+			expected: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut perspiciatis unde\nomnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem\naperiam. Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae\ndicta sunt explicabo.",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := DefaultWrapHelpString(tc.input)
+		if actual != tc.expected {
+			t.Errorf("Expected: %s, but got: %s", tc.expected, actual)
+		}
+	}
 }

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	as "github.com/aerospike/aerospike-client-go/v6"
+	"github.com/aerospike/tools-common-go/client"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -15,13 +16,13 @@ type FlagsTestSuite struct {
 func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 	testCases := []struct {
 		input  *AerospikeFlags
-		output *AerospikeConfig
+		output *client.AerospikeConfig
 	}{
 		{
 			&AerospikeFlags{
 				Seeds: HostTLSPortSliceFlag{
 					useDefault: false,
-					Seeds: HostTLSPortSlice{
+					Seeds: client.HostTLSPortSlice{
 						{
 							Host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						},
@@ -43,8 +44,8 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 					max: tls.VersionTLS13,
 				},
 			},
-			&AerospikeConfig{
-				Seeds: HostTLSPortSlice{
+			&client.AerospikeConfig{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						TLSName: "tls-name-1",
@@ -66,7 +67,7 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 			&AerospikeFlags{
 				Seeds: HostTLSPortSliceFlag{
 					useDefault: false,
-					Seeds: HostTLSPortSlice{
+					Seeds: client.HostTLSPortSlice{
 						{
 							Host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						},
@@ -87,8 +88,8 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 					max: tls.VersionTLS13,
 				},
 			},
-			&AerospikeConfig{
-				Seeds: HostTLSPortSlice{
+			&client.AerospikeConfig{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						TLSName: "tls-name-1",
@@ -104,7 +105,7 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 			&AerospikeFlags{
 				Seeds: HostTLSPortSliceFlag{
 					useDefault: false,
-					Seeds: HostTLSPortSlice{
+					Seeds: client.HostTLSPortSlice{
 						{
 							Host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 							Port: 3002,
@@ -125,8 +126,8 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 					max: tls.VersionTLS13,
 				},
 			},
-			&AerospikeConfig{
-				Seeds: HostTLSPortSlice{
+			&client.AerospikeConfig{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						Port: 3002,
@@ -147,7 +148,7 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 			&AerospikeFlags{
 				Seeds: HostTLSPortSliceFlag{
 					useDefault: false,
-					Seeds: HostTLSPortSlice{
+					Seeds: client.HostTLSPortSlice{
 						{
 							Host:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 							TLSName: "tls-name",
@@ -169,8 +170,8 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 					max: tls.VersionTLS13,
 				},
 			},
-			&AerospikeConfig{
-				Seeds: HostTLSPortSlice{
+			&client.AerospikeConfig{
+				Seeds: client.HostTLSPortSlice{
 					{
 						Host:    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
 						TLSName: "tls-name",
@@ -192,7 +193,7 @@ func (suite *FlagsTestSuite) TestSetAerospikeConf() {
 
 	for _, tc := range testCases {
 		suite.T().Run("", func(t *testing.T) {
-			actual := &AerospikeConfig{}
+			actual := &client.AerospikeConfig{}
 			SetAerospikeConf(actual, tc.input)
 			suite.Equal(tc.output, actual)
 		})

--- a/flags/host.go
+++ b/flags/host.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/aerospike/tools-common-go/client"
 )
 
 const (
@@ -12,75 +14,25 @@ const (
 	DefaultIPv4 = "127.0.0.1"
 )
 
-// HostTLSPort defines a Cobra compatible flag
-// for <host>:[<tls-name>:]<port> format flags.
-// Example configs include...
-// --host
-type HostTLSPort struct {
-	Host    string
-	TLSName string
-	Port    int
-}
-
-func (addr *HostTLSPort) String() string {
-	str := addr.Host
-
-	if addr.TLSName != "" {
-		str = fmt.Sprintf("%s:%s", str, addr.TLSName)
-	}
-
-	if addr.Port != 0 {
-		str = fmt.Sprintf("%s:%v", str, addr.Port)
-	}
-
-	return str
-}
-
-func NewDefaultHostTLSPort() *HostTLSPort {
-	return &HostTLSPort{
-		DefaultIPv4,
-		"",
-		DefaultPort,
-	}
-}
-
-type HostTLSPortSlice []*HostTLSPort
-
-func (slice *HostTLSPortSlice) String() string {
-	strs := []string{}
-
-	for _, elem := range *slice {
-		strs = append(strs, elem.String())
-	}
-
-	if len(strs) == 1 {
-		return strs[0]
-	}
-
-	str := fmt.Sprintf("[%s]", strings.Join(strs, ", "))
-
-	return str
-}
-
 // A cobra PFlag to parse and display help info for the host[:tls-name][:port]
 // input option.  It implements the pflag Value and SliceValue interfaces to
 // enable automatic parsing by cobra.
 type HostTLSPortSliceFlag struct {
 	useDefault bool
-	Seeds      HostTLSPortSlice
+	Seeds      client.HostTLSPortSlice
 }
 
 func NewHostTLSPortSliceFlag() HostTLSPortSliceFlag {
 	return HostTLSPortSliceFlag{
 		useDefault: true,
-		Seeds: HostTLSPortSlice{
-			NewDefaultHostTLSPort(),
+		Seeds: client.HostTLSPortSlice{
+			client.NewDefaultHostTLSPort(),
 		},
 	}
 }
 
-func parseHostTLSPort(v string) (*HostTLSPort, error) {
-	host := &HostTLSPort{}
+func parseHostTLSPort(v string) (*client.HostTLSPort, error) {
+	host := &client.HostTLSPort{}
 	ipv6HostPattern := `^\[(?P<host>.*)\]`
 	hostPattern := `^(?P<host>[^:]*)` // matched ipv4 and hostname
 	tlsNamePattern := `(?P<tlsName>.*)`
@@ -157,7 +109,7 @@ func (slice *HostTLSPortSliceFlag) Append(val string) error {
 
 // Replace will fully overwrite any data currently in the flag value list.
 func (slice *HostTLSPortSliceFlag) Replace(vals []string) error {
-	slice.Seeds = HostTLSPortSlice{}
+	slice.Seeds = client.HostTLSPortSlice{}
 
 	for _, val := range vals {
 		if err := slice.Append(val); err != nil {

--- a/flags/tlsprotocol.go
+++ b/flags/tlsprotocol.go
@@ -4,41 +4,23 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strings"
+
+	"github.com/aerospike/tools-common-go/client"
 )
-
-const (
-	VersionTLSDefaultMin = tls.VersionTLS12
-	VersionTLSDefaultMax = tls.VersionTLS12
-)
-
-type TLSProtocol uint16
-
-func (p TLSProtocol) String() string {
-	switch p {
-	case tls.VersionTLS10:
-		return "TLSV1"
-	case tls.VersionTLS11:
-		return "TLSV1.1"
-	case tls.VersionTLS12:
-		return "TLSV1.2"
-	}
-
-	return ""
-}
 
 // TLSProtocolsFlag defines a Cobra compatible flag
 // for dealing with tls protocols.
 // Example flags include.
 // --tls--protocols
 type TLSProtocolsFlag struct {
-	min TLSProtocol
-	max TLSProtocol
+	min client.TLSProtocol
+	max client.TLSProtocol
 }
 
 func NewDefaultTLSProtocolsFlag() TLSProtocolsFlag {
 	return TLSProtocolsFlag{
-		min: VersionTLSDefaultMin,
-		max: VersionTLSDefaultMax,
+		min: client.VersionTLSDefaultMin,
+		max: client.VersionTLSDefaultMax,
 	}
 }
 
@@ -54,7 +36,7 @@ func (flag *TLSProtocolsFlag) Set(val string) error {
 	tlsAll := tlsV1 | tlsV1_1 | tlsV1_2
 	tokens := strings.Fields(val)
 	protocols := uint8(0)
-	protocolSlice := []TLSProtocol{
+	protocolSlice := []client.TLSProtocol{
 		tls.VersionTLS10,
 		tls.VersionTLS11,
 		tls.VersionTLS12,

--- a/flags/tlsprotocol_test.go
+++ b/flags/tlsprotocol_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"testing"
 
+	"github.com/aerospike/tools-common-go/client"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,8 +21,8 @@ func (suite *FlagsTestSuite) TestTLSProtocolsFlag() {
 		{
 			"",
 			TLSProtocolsFlag{
-				min: VersionTLSDefaultMin,
-				max: VersionTLSDefaultMax,
+				min: client.VersionTLSDefaultMin,
+				max: client.VersionTLSDefaultMax,
 			},
 			false,
 		},


### PR DESCRIPTION
Moved tls, hosts, and policy logic from the uda to the common library. I assume this is a good way to go, considering that this library is currently a collection of helpers to make interacting with the go-client easier from a cmd line application.

I also added some unit tests (mostly around tls) that used to be covered by QE e2e tests in the uda.