### PR TITLE
feat: TOOLS-2973 add ability to set default config location

### DIFF
--- a/config/conf.go
+++ b/config/conf.go
@@ -12,12 +12,25 @@ import (
 // This is only needed because if "instance". Otherwise we would just run
 // RegisterAlias inside the BindPFlags function.
 var configToFlagMap = map[string]string{}
+var confDirs = []string{".", DefaultConfDir}
+var confName = DefaultConfName
+
+// SetConfDirs sets the directories to search for the config file when a file
+// name is not explicitly provided. If a file name is explicitly provided viper
+// checks both relative and absolute file paths.
+func SetConfDirs(dirs []string) {
+	confDirs = dirs
+}
+
+// SetConfName sets the name of the config file to search for. For aerospike
+// tools this is astools but for asvec it is asvec.
+func SetConfName(name string) {
+	confName = name
+}
 
 // InitConfig reads in config file and ENV variables if set. Should be called
 // from the root commands PersistentPreRunE function with the flags of the current command.
-func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (string, error) {
-	configFileUsed := ""
-
+func InitConfig(userProvidedCfgFile string) (string, error) {
 	if userProvidedCfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(userProvidedCfgFile)
@@ -27,9 +40,11 @@ func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (str
 			viper.SetConfigType("toml")
 		}
 	} else {
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(AsToolsConfDir)
-		viper.SetConfigName(AsToolsConfName)
+		for _, d := range confDirs {
+			viper.AddConfigPath(d)
+		}
+
+		viper.SetConfigName(confName)
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -40,7 +55,7 @@ func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (str
 		} else if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// We are relying on the default config file destination. If the
 			// file is not found don't consider it an error.
-			viper.SetConfigName(AsToolsConfName + ".conf")
+			viper.SetConfigName(confName + ".conf")
 			viper.SetConfigType("toml")
 
 			if err := viper.ReadInConfig(); err != nil {
@@ -51,12 +66,10 @@ func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (str
 		}
 	}
 
-	configFileUsed = viper.ConfigFileUsed()
+	return viper.ConfigFileUsed(), nil
+}
 
-	if configFileUsed == "" {
-		return "", nil
-	}
-
+func SetFlags(instance string, flags *pflag.FlagSet) error {
 	var persistedErr error
 
 	flags.VisitAll(func(f *pflag.Flag) {
@@ -86,7 +99,7 @@ func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (str
 		}
 	})
 
-	return configFileUsed, persistedErr
+	return persistedErr
 }
 
 // BindPFlags binds the flags to viper. Should be called after the flag set is
@@ -116,10 +129,6 @@ func Reset() {
 }
 
 func getAlias(key, instance string) string {
-	if instance != "" {
-		instance = "_" + instance
-	}
-
 	if k, ok := configToFlagMap[key]; ok {
 		key = k
 	}
@@ -127,10 +136,12 @@ func getAlias(key, instance string) string {
 	keySplit := strings.SplitN(key, ".", 2)
 
 	if len(keySplit) == 1 {
-		return key
+		return instance + "." + key
 	}
 
-	keySplit[0] += instance
+	if instance != "" {
+		keySplit[0] += "_" + instance
+	}
 
 	return strings.Join(keySplit, ".")
 }

--- a/config/conf.go
+++ b/config/conf.go
@@ -136,7 +136,11 @@ func getAlias(key, instance string) string {
 	keySplit := strings.SplitN(key, ".", 2)
 
 	if len(keySplit) == 1 {
-		return instance + "." + key
+		if instance != "" {
+			return instance + "." + key
+		}
+
+		return key
 	}
 
 	if instance != "" {

--- a/config/conf.go
+++ b/config/conf.go
@@ -18,19 +18,19 @@ var confName = DefaultConfName
 // SetConfDirs sets the directories to search for the config file when a file
 // name is not explicitly provided. If a file name is explicitly provided viper
 // checks both relative and absolute file paths.
-func SetConfDirs(dirs []string) {
+func SetDefaultConfDirs(dirs []string) {
 	confDirs = dirs
 }
 
 // SetConfName sets the name of the config file to search for. For aerospike
 // tools this is astools but for asvec it is asvec.
-func SetConfName(name string) {
+func SetDefaultConfName(name string) {
 	confName = name
 }
 
 // InitConfig reads in config file and ENV variables if set. Should be called
 // from the root commands PersistentPreRunE function with the flags of the current command.
-func InitConfig(userProvidedCfgFile string) (string, error) {
+func InitConfig(userProvidedCfgFile, instance string, flags *pflag.FlagSet) (string, error) {
 	if userProvidedCfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(userProvidedCfgFile)
@@ -66,7 +66,7 @@ func InitConfig(userProvidedCfgFile string) (string, error) {
 		}
 	}
 
-	return viper.ConfigFileUsed(), nil
+	return viper.ConfigFileUsed(), SetFlags(instance, flags)
 }
 
 func SetFlags(instance string, flags *pflag.FlagSet) error {

--- a/config/conf_test.go
+++ b/config/conf_test.go
@@ -81,14 +81,9 @@ func (suite *ConfigTestSuite) NewCmds(file, instance string) (rootCmd, cmd1, cmd
 	rootCmd = &cobra.Command{
 		Use: "test",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			cfgFileTmp, err := InitConfig(file)
+			cfgFileTmp, err := InitConfig(file, instance, cmd.Flags())
 			if err != nil {
 				return fmt.Errorf("Failed to initialize config: %s", err)
-			}
-
-			err = SetFlags(instance, cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("Failed to set flags: %s", err)
 			}
 
 			suite.actualCfgFile = cfgFileTmp

--- a/config/conf_test.go
+++ b/config/conf_test.go
@@ -81,9 +81,14 @@ func (suite *ConfigTestSuite) NewCmds(file, instance string) (rootCmd, cmd1, cmd
 	rootCmd = &cobra.Command{
 		Use: "test",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			cfgFileTmp, err := InitConfig(file, instance, cmd.Flags())
+			cfgFileTmp, err := InitConfig(file)
 			if err != nil {
 				return fmt.Errorf("Failed to initialize config: %s", err)
+			}
+
+			err = SetFlags(instance, cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("Failed to set flags: %s", err)
 			}
 
 			suite.actualCfgFile = cfgFileTmp
@@ -244,6 +249,42 @@ func (suite *ConfigTestSuite) TestInitConfigWithInstance() {
 	intVal, err := cmd1.Flags().GetInt("int")
 	suite.NoError(err)
 	suite.Equal(5000, intVal)
+
+	boolVal, err := cmd1.Flags().GetBool("bool")
+	suite.NoError(err)
+	suite.Equal(true, boolVal)
+
+	suite.Equal(suite.actualCfgFile, suite.file)
+}
+
+// This is used by asvec. Instead of having a group like cluster,asadm,aql etc.
+// and adding and _{instance} to the group to select config params it uses and
+// empty group and uses then instance arg as the group name. Affectively
+// allowing the user to define the full group name at runtime.
+func (suite *ConfigTestSuite) TestInitConfigWithoutGroupsButWithInstance() {
+	rootCmd, cmd1, _ := suite.NewCmds(suite.file, "group1")
+
+	flagSet := &pflag.FlagSet{}
+	flagSet.String("str", "", "string flag")
+	flagSet.Int("int", 0, "int flag")
+	flagSet.Bool("bool", false, "bool flag")
+	BindPFlags(flagSet, "")
+
+	cmd1.Flags().AddFlagSet(flagSet)
+
+	// Cmd1
+	rootCmd.SetArgs([]string{"test1"})
+	err := rootCmd.Execute()
+
+	suite.NoError(err)
+
+	str, err := cmd1.Flags().GetString("str")
+	suite.NoError(err)
+	suite.Equal("localhost:3000", str)
+
+	intVal, err := cmd1.Flags().GetInt("int")
+	suite.NoError(err)
+	suite.Equal(3000, intVal)
 
 	boolVal, err := cmd1.Flags().GetBool("bool")
 	suite.NoError(err)

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,6 +1,6 @@
 package config
 
 const (
-	AsToolsConfDir  = "/etc/aerospike"
-	AsToolsConfName = "astools"
+	DefaultConfDir  = "/etc/aerospike"
+	DefaultConfName = "astools"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -265,14 +265,9 @@ func (suite *ConfTestSuite) NewTestCmd() (*cobra.Command, *flags.ConfFileFlags, 
 		Use:   "test",
 		Short: "test cmd",
 		Run: func(cmd *cobra.Command, _ []string) {
-			_, err := config.InitConfig(configFileFlags.File)
+			_, err := config.InitConfig(configFileFlags.File, configFileFlags.Instance, cmd.Flags())
 			if err != nil {
 				suite.FailNow("Failed to initialize config", err)
-			}
-
-			err = config.SetFlags(configFileFlags.Instance, cmd.Flags())
-			if err != nil {
-				suite.FailNow("Failed to set flags", err)
 			}
 		},
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -265,9 +265,14 @@ func (suite *ConfTestSuite) NewTestCmd() (*cobra.Command, *flags.ConfFileFlags, 
 		Use:   "test",
 		Short: "test cmd",
 		Run: func(cmd *cobra.Command, _ []string) {
-			_, err := config.InitConfig(configFileFlags.File, configFileFlags.Instance, cmd.Flags())
+			_, err := config.InitConfig(configFileFlags.File)
 			if err != nil {
 				suite.FailNow("Failed to initialize config", err)
+			}
+
+			err = config.SetFlags(configFileFlags.Instance, cmd.Flags())
+			if err != nil {
+				suite.FailNow("Failed to set flags", err)
 			}
 		},
 	}

--- a/flags/configFileFlags.go
+++ b/flags/configFileFlags.go
@@ -22,7 +22,7 @@ func NewConfFileFlags() *ConfFileFlags {
 func (cf *ConfFileFlags) NewFlagSet(fmtUsage UsageFormatter) *pflag.FlagSet {
 	f := &pflag.FlagSet{}
 
-	f.StringVar(&cf.File, "config-file", "", fmtUsage(fmt.Sprintf("Config file (default is %s/%s)", config.AsToolsConfDir, config.AsToolsConfName)))                                                                                    //nolint:lll //Reason: Wrapping this line would make editing difficult.
+	f.StringVar(&cf.File, "config-file", "", fmtUsage(fmt.Sprintf("Config file (default is %s/%s)", config.DefaultConfDir, config.DefaultConfName)))                                                                                    //nolint:lll //Reason: Wrapping this line would make editing difficult.
 	f.StringVar(&cf.Instance, "instance", "", fmtUsage("For support of the aerospike tools toml schema. Sections with the instance are read. e.g in the case where instance 'a' is specified sections 'cluster_a', 'uda_a' are read.")) //nolint:lll //Reason: Wrapping this line would make editing difficult.
 
 	return f


### PR DESCRIPTION
This PR adds flexibility to config file usage. We now support having a config file with a different name/location from `/etc/aerospike/astools.yaml`(or .conf). 